### PR TITLE
set cursor to pointer to about link

### DIFF
--- a/src/app/about/about.page.scss
+++ b/src/app/about/about.page.scss
@@ -4,4 +4,8 @@
 }
 a {
   color: var(--ion-color-tertiary);
+
+  &:not([href]) {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
The links in the about page show the cursor as text when hovered. It is not clear to the user that the link can be clicked. Now, the cursor will be set as a pointer.

This issue is due to the missing href attribute.