### PR TITLE
Wrong position in B vs 3p

### DIFF
--- a/code/src/static/endgamedatabase.json
+++ b/code/src/static/endgamedatabase.json
@@ -3154,7 +3154,7 @@
                             "target": "checkmate"
                         },
                         {
-                            "fen": "8/p3B3/8/8/1pp5/1k6/8/1K6 b - - 0 1",
+                            "fen": "8/p3B3/8/8/1pp5/1k6/8/1K6 w - - 0 1",
                             "target": "draw"
                         },
                         {
@@ -15013,5 +15013,5 @@
             ]
         }
     ],
-    "version": 23
+    "version": 24
 }


### PR DESCRIPTION
in B vs 3p [2/7] starts the player right now as black with 3 pawns and has to draw against white with one bishop. The position is a draw, it makes no sense to hold the draw against one bishop.
I only changed the fen in the endgame database to switch colors.