### PR TITLE
report syzygy mate distance in moves not plies

### DIFF
--- a/code/src/controllers/position.ts
+++ b/code/src/controllers/position.ts
@@ -1102,6 +1102,15 @@ class PositionController extends BaseController {
     }
   }
 
+  /**
+   * Syzygy reports distance to mate in plies, stockfish's `score mate` in moves. Both end up
+   * in mateDistance and are announced with the same position.mate-in message, so syzygy's
+   * figure is converted to keep the two sources saying the same thing.
+   */
+  private static dtmToMoves(dtm: number): number {
+    return Math.sign(dtm) * Math.ceil(Math.abs(dtm) / 2);
+  }
+
   private getSyzygyMove() {
     this.waitingForOpponent.value = true;
     this.syzygyCandidates = [];
@@ -1158,7 +1167,7 @@ class PositionController extends BaseController {
         const from = match[1];
         const to = match[2];
         const promotion = match[3];
-        if (move.dtm) this.mateDistance = move.dtm * (this.chess.turn() == this.player.value ? -1 : 1) * (this.player.value == 'b' ? -1 : 1);
+        if (move.dtm) this.mateDistance = PositionController.dtmToMoves(move.dtm) * (this.chess.turn() == this.player.value ? -1 : 1) * (this.player.value == 'b' ? -1 : 1);
         this.processOpponentMove(from, to, promotion);
       })
       ).catch((_err) => {


### PR DESCRIPTION
the mate in N message gets its number from two different places

getSyzygyMove takes it from the tablebase which counts in plies
stockfishMessage takes it from score mate which uci counts in moves

so the same message means two different things depending on which one answered and the tablebase one comes out about double

to reproduce open pawn / pawn vs king 39 which is a draw you have to hold then play the losing king move e7

the tablebase gives the resulting position as dtm 38 which is 19 moves
the toast says **you are receiving mate in 38 moves or less**
with this change it says **19**

the conversion happens where the tablebase number gets read so both sources end up saying the same thing