### PR TITLE
fix two fens that load as the starting position

### DIFF
--- a/code/src/static/endgamedatabase.json
+++ b/code/src/static/endgamedatabase.json
@@ -7128,7 +7128,7 @@
                             "target": "checkmate"
                         },
                         {
-                            "fen": "2K5/8/3p2R1/5p1k/8/8/8/8 w - - dm 40 0 1",
+                            "fen": "2K5/8/3p2R1/5p1k/8/8/8/8 w - - 0 1",
                             "target": "checkmate"
                         },
                         {
@@ -9680,7 +9680,7 @@
                             "target": "checkmate"
                         },
                         {
-                            "fen": "8/6r1/1R6/3B4/8/8/8/3K2k1 w - -0 0 1",
+                            "fen": "8/6r1/1R6/3B4/8/8/8/3K2k1 w - - 0 1",
                             "target": "checkmate"
                         },
                         {


### PR DESCRIPTION
two entries have a broken field after the castling rights

```
rook-pawn / rook vs two pawns 29       2K5/8/3p2R1/5p1k/8/8/8/8 w - - dm 40 0 1
rook-pieces / rook bishop vs rook 20   8/6r1/1R6/3B4/8/8/8/3K2k1 w - -0 0 1
```

chess.js load returns false for both and leaves the board untouched so opening either puzzle gives you a full starting position instead of the endgame and nothing tells you anything went wrong

checked against the bundled chess.js
before load is false and the board has 32 pieces
after load is true and the board has 5

only the broken field is touched
both are still the wins the checkmate target says they are the tablebase gives them as dtm 79 and dtm 59

found these while writing the script for #14